### PR TITLE
Better Command Names

### DIFF
--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptLibraryMappings">
+    <includedPredefinedLibrary name="Node.js Core" />
+  </component>
+</project>

--- a/bot/cmds/photon/car.js
+++ b/bot/cmds/photon/car.js
@@ -3,10 +3,10 @@ const Command = require("../findercommand")
 module.exports = class CarCommand extends Command {
 	constructor(client) {
 		super(client, {
-			name: 'car',
+			name: 'car-detail',
 			group: 'photon',
 			memberName: 'car',
-			description: 'Search for vehicle names used in photon addons.',
+			description: 'Gives detailed information on a single vehicle.',
 			args: [{
 				key: 'path',
 				label: 'Vehicle Name',

--- a/bot/cmds/photon/cars.js
+++ b/bot/cmds/photon/cars.js
@@ -3,10 +3,10 @@ const Command = require("../reportcommand")
 module.exports = class CarsCommand extends Command {
 	constructor(client) {
 		super(client, {
-			name: 'cars',
+			name: 'car-search',
 			group: 'photon',
 			memberName: 'cars',
-			description: 'Search for vehicle names used in photon addons.',
+			description: 'Search for vehicle names used in photon addons, and returns a list of vehicle names.',
 			args: [{
 				key: 'path',
 				label: 'Vehicle Name',

--- a/bot/cmds/photon/component.js
+++ b/bot/cmds/photon/component.js
@@ -3,10 +3,10 @@ const Command = require("../findercommand")
 module.exports = class ComponentCommand extends Command {
 	constructor(client) {
 		super(client, {
-			name: 'component',
+			name: 'component-detail',
 			group: 'photon',
 			memberName: 'component',
-			description: 'Search for component names used in photon addons.',
+			description: 'Gives detailed information on a single component.',
 			args: [{
 				key: 'path',
 				label: 'Component Name',

--- a/bot/cmds/photon/components.js
+++ b/bot/cmds/photon/components.js
@@ -3,10 +3,10 @@ const Command = require("../reportcommand")
 module.exports = class ComponentsCommand extends Command {
 	constructor(client) {
 		super(client, {
-			name: 'components',
+			name: 'component-search',
 			group: 'photon',
 			memberName: 'components',
-			description: 'Search for component names used in photon addons.',
+			description: 'Search for component names used in photon addons, and returns a list of component names.',
 			args: [{
 				key: 'path',
 				label: 'Component Name',

--- a/bot/cmds/photon/path.js
+++ b/bot/cmds/photon/path.js
@@ -3,10 +3,10 @@ const Command = require("../findercommand")
 module.exports = class PathCommand extends Command {
 	constructor(client) {
 		super(client, {
-			name: 'path',
+			name: 'path-detail',
 			group: 'photon',
 			memberName: 'path',
-			description: 'Search for lua files used in photon addons.',
+			description: 'Gives detailed information on a single file path.',
 			args: [{
 				key: 'path',
 				label: 'File Path',

--- a/bot/cmds/photon/paths.js
+++ b/bot/cmds/photon/paths.js
@@ -3,10 +3,10 @@ const Command = require("../reportcommand")
 module.exports = class PathsCommand extends Command {
 	constructor(client) {
 		super(client, {
-			name: 'paths',
+			name: 'path-search',
 			group: 'photon',
 			memberName: 'paths',
-			description: 'Search for lua files used in photon addons.',
+			description: 'Search for lua files used in photon addons, and returns a list of paths.',
 			args: [{
 				key: 'path',
 				label: 'File Path',


### PR DESCRIPTION
Renamed commands to type-search or type-detail, for a broad search or details on a single type respectively.
Types are car, component and path, as before.

Fixes #1.